### PR TITLE
Fix errors from rustty bump and appease rustc warnings

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -2,10 +2,10 @@ use std::char;
 use std::cmp::{max, min};
 use std::collections::VecDeque;
 use num::{Complex, Float};
-use rustty;
 use rustty::{Attr, Color, Terminal, Cell, CellAccessor, HasSize};
 use rustty::ui::{Alignable, Widget, VerticalAlign, HorizontalAlign};
 use itertools::{Itertools, EitherOrBoth};
+use std::io;
 
 pub struct Canvas {
     term: Terminal,
@@ -15,7 +15,7 @@ pub struct Canvas {
 }
 
 impl Canvas {
-    pub fn new() -> Result<Self, rustty::Error> {
+    pub fn new() -> Result<Self, io::Error> {
         let term = try!(Terminal::new());
 
         let mut canvas = Canvas {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use docopt::Docopt;
 use radio::hackrf::HackRF;
 use drawing::Canvas;
 use processing::process_signal;
+use std::time::Duration;
 
 const USAGE: &'static str = "
 Terminal Spectrograph
@@ -70,7 +71,7 @@ fn main() {
 
     for spec in spec_recv.iter() {
         canvas.add_spectrum(spec);
-        if let Ok(Some(Event::Key('q'))) = canvas.get_term().get_event(0) {
+        if let Ok(Some(Event::Key('q'))) = canvas.get_term().get_event(Duration::from_secs(0)) {
             break;
         }
 

--- a/src/radio/hackrf/mod.rs
+++ b/src/radio/hackrf/mod.rs
@@ -57,13 +57,13 @@ mod ffi {
 fn init() -> Result<(), ()> {
     //TODO how do I call hackrf_exit()?
     static mut INIT: Once = ONCE_INIT;
-    static mut result: ffi::Return = ffi::Return::SUCCESS;
+    static mut RESULT: ffi::Return = ffi::Return::SUCCESS;
     unsafe {
         INIT.call_once(|| {
-            result = ffi::hackrf_init();
+            RESULT = ffi::hackrf_init();
         });
 
-        match result {
+        match RESULT {
             ffi::Return::SUCCESS => Ok(()),
             _ => Err(()),
         }


### PR DESCRIPTION
src/drawing.rs
- fix compile error because rustty switched its error type from ```rustty::Error``` to ```std::io::Error```

src/main.rs
- fix compile error because ```tty.get_event(..)``` now takes a ```std::time::Duration``` instead of an int for its timeout

src/radio/hackrf/mod.rs
- change ```static result``` to ```static RESULT``` to appease rustc